### PR TITLE
Update 2048.py

### DIFF
--- a/2048.py
+++ b/2048.py
@@ -50,6 +50,30 @@ def move(board, direction):
                         new_board[temp_row + 1][col] *= 2
                         new_board[temp_row][col] = 0
                         merged[temp_row + 1][col] = True
+	#Fixes #18					
+	elif direction == 'down':
+		for col in range(4):
+			tiles = [new_board[r][col] for r in range(4) if new_board[r][col] != 0]
+			tiles = tiles[::-1]  
+        
+			merged_tiles = []
+			skip = False
+			for i in range(len(tiles)):
+				if skip:
+					skip = False
+					continue
+				if i + 1 < len(tiles) and tiles[i] == tiles[i+1]:
+					merged_tiles.append(tiles[i] * 2)
+					skip = True
+				else:
+					merged_tiles.append(tiles[i])
+        
+			merged_tiles = merged_tiles[::-1]
+			for r in range(4):
+				if r < 4 - len(merged_tiles):
+					new_board[r][col] = 0
+				else:
+					new_board[r][col] = merged_tiles[r - (4 - len(merged_tiles))]
 
     elif direction == 'left':
         for row in range(4):


### PR DESCRIPTION
Fixes [#18](https://github.com/sz30/2048--/issues/18),

After reviewing the move() function in 2048.py, I suspect the bug is in the 'down' direction logic.
The current implementation iterates row by row and slides tiles one step at a time, which may cause incorrect behavior when multiple tiles are stacked in the same column — a tile that has already moved can interfere with the sliding of tiles above it, leaving top-row tiles "stuck".
A compress-then-merge approach might be more reliable.
May I submit a PR to help fix it?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the down move handling in the 2048 game to address gameplay logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->